### PR TITLE
remove flag

### DIFF
--- a/sci_gateway/cpp/builder_gateway_cpp.sce
+++ b/sci_gateway/cpp/builder_gateway_cpp.sce
@@ -63,7 +63,7 @@ function builder_gateway_cpp()
     inter_cflags = ilib_include_flag([OPENCV_INCLUDE,gw_cpp_path,fullfile(gw_cpp_path,"..","..","src","cpp")]); 
     if getos() == "Windows" then
         inter_cflags = inter_cflags + " /std:c++17";
-    else
+    elseif getos() == "Linux"
         inter_cflags = inter_cflags + " -std=c++17";
     end
     inter_ldflags = "";

--- a/src/cpp/builder_cpp.sce
+++ b/src/cpp/builder_cpp.sce
@@ -22,7 +22,7 @@ function builder_cpp()
     cflags = ilib_include_flag([src_cpp_path, opencv_include]);
     if getos() == "Windows" then
         cflags = cflags + " /std:c++17";
-    else
+    elseif getos() == "Linux"
         cflags = cflags + " -std=c++17";
     end
 


### PR DESCRIPTION
Scilab configure makes test of the compiler with C sources and clang raises an error when compiling C with --std=c++17  (seems that gcc just ignores it).